### PR TITLE
Fix /block giving Ink Sac's and glowstone amount

### DIFF
--- a/src/me/sirfaizdat/prison/core/BlockCommand.java
+++ b/src/me/sirfaizdat/prison/core/BlockCommand.java
@@ -174,7 +174,7 @@ public class BlockCommand implements CommandExecutor {
 					new ItemStack[] { new ItemStack(cO > 0 ? Material.COAL
 							: Material.AIR, cO) });
 
-			player.sendMessage(MessageUtil.get("general.blocksCompacted", itemsChanged + "", "" + (itemsChanged / 9)));
+			player.sendMessage(MessageUtil.get("general.blocksCompacted", itemsChanged + "", "" + (diamondsToTransform + emeraldsToTransform + glowstoneToTransform + goldToTransform + ironToTransform + lT + rT + cT)));
 			player.updateInventory();
 		} catch (Exception e) {
 			e.printStackTrace();


### PR DESCRIPTION
Fixes /block giving Ink Sac's instead of Lapis Lazuli.
Fixes /block converting 9 glowstone dust to blocks instead of 4 glowstone dust like in vanilla crafting recipies.
