### PR TITLE
Add Multiworld as soft dependency in plugin.yml

### DIFF
--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -5,7 +5,7 @@ author: SirFaizdat
 authors: [Camouflage100]
 main: me.sirfaizdat.prison.core.Prison
 depend: [Vault, WorldEdit]
-softdepend: [Multiverse-Core]
+softdepend: [Multiverse-Core,Multiworld]
 website: http://github.com/SirFaizdat/Prison/wiki
 
 commands:


### PR DESCRIPTION
Add Multiworld as soft dependency in plugin.yml, to make it load before Prison. Fixing the same issue as commit 08a43f9, but for Multiworld users as well.